### PR TITLE
Aggregate report data for printing

### DIFF
--- a/pdf_report_designer/models/report_pdf.py
+++ b/pdf_report_designer/models/report_pdf.py
@@ -340,21 +340,20 @@ class ReportPDF(models.Model):
         """ Create a contextual action for each server action."""
         self.action_button = True
         windowaction = self.env['ir.actions.act_window']
-        data = self.env['ir.model.data']
+        # Use correct view reference for the wizard form
+        wizard_view = self.env.ref('pdf_report_designer.pdf_report_view_form', raise_if_not_found=False)
         for rec in self.browse(self._ids):
             binding_model_id = rec.model_id.id
-            model_data_id = data._load_xmlid('pdf_report_designer')
-            res_id = data.browse(model_data_id).res_id
             button_name = _('Print Report (%s)') % rec.name
             act_id = windowaction.create({
                 'name': button_name,
-                'is_action_created_from_pdf_report':True,
+                'is_action_created_from_pdf_report': True,
                 'type': 'ir.actions.act_window',
                 'res_model': 'pdf.report',
                 'binding_model_id': binding_model_id,
                 'context': "{'pdf' : %d, 'header': '%s'}" % (rec.id, rec.name),
                 'view_mode': 'form,tree',
-                'view_id': res_id,
+                'view_id': wizard_view.id if wizard_view else False,
                 'target': 'new',
             })
             rec.write({

--- a/pdf_report_designer/models/report_pdf.py
+++ b/pdf_report_designer/models/report_pdf.py
@@ -259,7 +259,7 @@ class ReportPDF(models.Model):
                 if rec.group_by_field and len(grouped_data) > 1:
                     summary_row = ["TOTAL"]
                     # Calculate totals for all numeric fields (monetary, integer, float)
-                    for field_id in order[1:]:  # Skip first field (SL.No)
+                    for field_id in order:  # Sum aligned to each data column
                         field_obj = self.env['ir.model.fields'].browse(int(field_id))
                         if field_obj.ttype in ['monetary', 'integer', 'float']:
                             total = sum(record[field_obj.name] for record in group_records if record[field_obj.name])

--- a/pdf_report_designer/report/pdf_report_templates.xml
+++ b/pdf_report_designer/report/pdf_report_templates.xml
@@ -79,9 +79,7 @@
                                     <t t-elif="rec[0] == 'TOTAL'">
                                         <!-- Summary Row -->
                                         <tr style="background-color: #e8f4fd; font-weight: bold;">
-                                            <td style="font-weight: bold; text-align: center;">
-                                                <t t-esc="rec[0]"/>
-                                            </td>
+                                            <td style="font-weight: bold; text-align: center;"></td>
                                             <t t-foreach="rec" t-as="j" t-start="1">
                                                 <td style="font-weight: bold; text-align: center;">
                                                     <t t-esc="j"/>
@@ -151,9 +149,7 @@
                                         <t t-elif="record[0] == 'TOTAL'">
                                             <!-- Summary Row -->
                                             <tr style="background-color: #e8f4fd; font-weight: bold;">
-                                                <td style="font-weight: bold; text-align: center;">
-                                                    <t t-esc="record[0]"/>
-                                                </td>
+                                                <td style="font-weight: bold; text-align: center;"></td>
                                                 <t t-foreach="record" t-as="rec" t-start="1">
                                                     <td style="font-weight: bold; text-align: center;">
                                                         <t t-esc="rec"/>

--- a/pdf_report_designer/wizard/pdf_report.py
+++ b/pdf_report_designer/wizard/pdf_report.py
@@ -173,7 +173,7 @@ class PDFReportWizard(models.TransientModel):
                 if rec.group_by_field and len(grouped_data) > 1:
                     summary_row = ["TOTAL"]
                     # Calculate totals for all numeric fields (monetary, integer, float)
-                    for field_id in order[1:]:  # Skip first field (SL.No)
+                    for field_id in order:  # Sum aligned to each data column
                         field_obj = self.env['ir.model.fields'].browse(int(field_id))
                         if field_obj.ttype in ['monetary', 'integer', 'float']:
                             total = sum(record[field_obj.name] for record in group_records if record[field_obj.name])


### PR DESCRIPTION
Implement grouping and totals in PDF reports generated via the wizard and correct the wizard's view reference for consistent output.

Previously, reports printed from the "Add Action" smart button (which uses a wizard) lacked the grouping and total calculations present when printing directly from the main "Print Report" button. This PR unifies the behavior, ensuring all generated PDF reports respect the `group_by_field` configuration, including group headers, aggregated totals for numeric fields, and proper view rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e4a4dfe-a761-4f7f-89bf-831e6bc9fc6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e4a4dfe-a761-4f7f-89bf-831e6bc9fc6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

